### PR TITLE
Add support for PHP 5.4 built-in webserver

### DIFF
--- a/web/index.php
+++ b/web/index.php
@@ -1,5 +1,10 @@
 <?php
 
+$filename = __DIR__.preg_replace('#(\?.*)$#', '', $_SERVER['REQUEST_URI']);
+if (php_sapi_name() === 'cli-server' && is_file($filename)) {
+    return false;
+}
+
 $app = require __DIR__ . '/../app/app.php';
 
 if ($app instanceof Silex\Application) {


### PR DESCRIPTION
The built in web server in PHP 5.4 is really convenient for local testing. This pull-request adds a few lines to enable static resources when using the built-in server as described here: http://silex.sensiolabs.org/doc/web_servers.html#php-5-4
